### PR TITLE
Use process.cwd() instead of process.env.PWD

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ var crypto = require('crypto')
       duration: 31556900,
       conditional: isDev ? 'none' : 'both',
       cacheControl: 'cookieless',
-      dir: path.join(process.env.PWD, 'public'),
+      dir: path.join(process.cwd(), 'public'),
       fingerprint: md5,
       location: 'prefile',
       loadCache: isDev ? 'furl' : 'startup',


### PR DESCRIPTION
By using process.cwd() instead of process.env.PWD, this module works on Windows.
