### PR TITLE
A couple small but important fixes for Azure

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ function fingerprintAssetUrl(assetUrl) {
   var options = expiry.options
     , parsedUrl = (typeof assetUrl === 'string') ? url.parse(assetUrl, true, true) : assetUrl
     , urlCacheKey = parsedUrl.path
-    , filePath = path.join(options.dir, parsedUrl.pathname)
+    , filePath = options.dir + '/' + parsedUrl.pathname
     , fingerprint
     , fingerprintedUrl;
 
@@ -168,20 +168,20 @@ function fingerprintAssetUrl(assetUrl) {
 
   switch (options.location) {
     case 'prefile':
-      parsedUrl.pathname = path.join(path.dirname(parsedUrl.pathname),
-        fingerprint + '-' + path.basename(parsedUrl.pathname));
+      parsedUrl.pathname = path.dirname(parsedUrl.pathname).replace(/\/$/, '') + '/' +
+        fingerprint + '-' + path.basename(parsedUrl.pathname);
       break;
     case 'postfile':
       var filename = path.basename(parsedUrl.pathname)
         , ext = path.extname(filename);
-      parsedUrl.pathname = path.join(path.dirname(parsedUrl.pathname),
-        filename.slice(0, -ext.length) + '-' + fingerprint + ext);
+      parsedUrl.pathname = path.dirname(parsedUrl.pathname).replace(/\/$/, '') + '/' +
+        filename.slice(0, -ext.length) + '-' + fingerprint + ext;
       break;
     case 'query':
       parsedUrl.query['v'] = fingerprint;
       break;
     case 'path':
-      parsedUrl.pathname = path.join('/', fingerprint, parsedUrl.pathname);
+      parsedUrl.pathname = '/' + fingerprint + parsedUrl.pathname;
       break;
   }
 


### PR DESCRIPTION
Two small commits to get static-expiry working on Azure.
- The first is related to Azure not populating process.env.PWD. This causes the app to crash once it hits require('static-expiry'). Stack trace attached in the commit message.
- The second is related to Windows systems using backslash ("\") as the path separator
  character is instead of slash ("/"). This causes problems using every URL generation location (prefile, postfile, path) except for query.

I made sure the unit tests are passing with these changes as well as tested my Node.js app running on Windows Azure.
