### PR TITLE
Bug fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,9 @@ function middleware(req, res, next) {
     }
     if (cacheControl.length) res.setHeader('Cache-Control', cacheControl);
 
-    if (fresh(req, res)) return res.send(304);
+    if (fresh(req.headers, (res._headers || {}))) {
+      return res.send(304);
+    }
 
     req.originalUrl = req.url;
     req.url = headerInfo.assetUrl;

--- a/index.js
+++ b/index.js
@@ -252,9 +252,14 @@ function middleware(req, res, next) {
     , options = expiry.options;
 
   if (headerInfo) {
-    var cacheControl = (options.cacheControl === 'cookieless' &&
-      (req.headers.cookie || req.headers.authorization)) ?
-          'private' : options.cacheControl || '';
+    var cacheControl = options.cacheControl || '';
+
+    // Treat cookieless as a special value where we switch
+    // between public and private based on presence of a cookie.
+    if(cacheControl === 'cookieless') {
+      cacheControl = (req.headers.cookie || req.headers.authorization) ?
+          'private' : 'public';
+    }
 
     if (options.unconditional === 'both' || options.unconditional === 'max-age') {
       if (cacheControl.length) cacheControl += ', ';

--- a/index.js
+++ b/index.js
@@ -252,8 +252,8 @@ function middleware(req, res, next) {
     , options = expiry.options;
 
   if (headerInfo) {
-    var cacheControl = (options.cacheControl === 'cookieless' && 
-      (req.get('cookie') || req.get('authorization'))) ?
+    var cacheControl = (options.cacheControl === 'cookieless' &&
+      (req.headers.cookie || req.headers.authorization)) ?
           'private' : options.cacheControl || '';
 
     if (options.unconditional === 'both' || options.unconditional === 'max-age') {
@@ -263,15 +263,15 @@ function middleware(req, res, next) {
     if (options.unconditional === 'both' || options.unconditional === 'expires') {
       var now = new Date();
       now.setSeconds(now.getSeconds() + options.duration);
-      res.set({ 'Expires' : now.toUTCString() });
+      res.setHeader('Expires', now.toUTCString());
     }
     if (options.conditional === 'both' || options.conditional === 'etag') {
-      res.set({ 'ETag' : '"' + headerInfo.etag + '"' });
+      res.setHeader('ETag', '"' + headerInfo.etag + '"');
     }
     if (options.conditional === 'both' || options.conditional === 'last-modified') {
-      res.set({ 'Last-Modified' : headerInfo.lastModified });
+      res.setHeader('Last-Modified', headerInfo.lastModified);
     }
-    if (cacheControl.length) res.set({ 'Cache-Control' : cacheControl });
+    if (cacheControl.length) res.setHeader('Cache-Control', cacheControl);
 
     if (fresh(req, res)) return res.send(304);
 
@@ -298,7 +298,13 @@ function expiry(app, options) {
     (typeof options.loadCache === 'object' && options.loadCache.at === 'startup')) {
     preCache();
   }
-  if (options.debug) app.get('/expiry', expiryGet);
+
+  if (options.debug)
+    app.get('/expiry', expiryGet);
+
+  if(!app.locals)
+    app.locals = {};
+
   app.locals.furl = furl;
 
   return middleware;

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ exports.setOptions = function(opts) {
 /**
  * lookup for fingerprinted URLS
  *
- * { '/css/main.css': '/css/ea37c65807fe8adfbaf8bc2a2cef7a54-style.css', ... }
+ * { '/css/main.css': '/css/ea37c65807fe8adfbaf8bc2a2cef7a54-main.css', ... }
  */
 exports.urlCache = {};
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "findit": "0.1.2"
   },
   "devDependencies": {
-    "should": "*",
-    "mocha": "*"
-  },  
+    "mocha": "3.x.x",
+    "should": "*"
+  },
   "main": "index",
   "engines": {
     "node": ">=4.x.x"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "author": "Paul Walker",
   "dependencies": {
-    "fresh": "0.1.0",
+    "fresh": "0.3.0",
     "findit": "0.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "findit": "0.1.2"
   },
   "devDependencies": {
+    "connect": "3.x.x",
     "mocha": "3.x.x",
-    "should": "11.x.x"
+    "should": "11.x.x",
+    "supertest": "^2.0.1"
   },
   "main": "index",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "mocha": "3.x.x",
-    "should": "*"
+    "should": "11.x.x"
   },
   "main": "index",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },  
   "main": "index",
   "engines": {
-    "node": ">= 0.8.21"
+    "node": ">=4.x.x"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,3 @@
 --growl
 --ui bdd
 --reporter spec
---ignore-leaks

--- a/test/test.js
+++ b/test/test.js
@@ -117,5 +117,20 @@ describe("middleware", function() {
             throw new Error("Unexpected caching header");
         });
     });
+
+    it("sets cache-control to public or private dynamically when cacheControl: cookieless", function() {
+      return Promise.all([
+        // The no-cookie version returns cache-control public.
+        request(app)
+        .get(util.format('/%s-styles.css', stylesHash))
+        .expect("Cache-Control", /^public\,/),
+
+        // The cookie version returns cache-control private
+        request(app)
+        .get(util.format('/%s-styles.css', stylesHash))
+        .set('Cookie', 'dummy-cookie')
+        .expect("Cache-Control", /^private\,/)
+      ]);
+    });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ describe('furl', function() {
   it('uses the second argument when in prod mode', function() {
     expiry.options.useSecond = true;
     var result = app.locals.furl('/styles.css', '/styles.min.css');
-    result.should.include('styles.min.css');
+    result.should.containEql('styles.min.css');
   });
 
   it('uses a host', function() {


### PR DESCRIPTION
Hi,

Thanks for this library! 

This PR contains a few bug fixes, while also tweaking bits of code that would no longer run because dependencies had changed their APIs. It should be pretty simple to follow commit by commit, but here's a brief run down of the changes:

1. Get the tests running again, by removing usages of options and functions from mocha and should.js that no longer exist.

2. Get the library working without express, by replacing calls to express-specific request/response object methods with the bare node equivalents. Add tests for this.

3. Fix a bug where the response could include the header `Cache-Control: cookieless` rather than `Cache-Control: public` and add a test for that.

4. Update the minimum node version, because the previous minimum version is not maintained and insecure.