### PR TITLE
Fix debug route with connect

### DIFF
--- a/index.js
+++ b/index.js
@@ -307,7 +307,7 @@ function expiry(app, options) {
   }
 
   if (options.debug)
-    app.get('/expiry', expiryGet);
+    app.use('/expiry', expiryGet);
 
   if(!app.locals)
     app.locals = {};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "connect": "3.x.x",
+    "express": "^4.14.0",
     "mocha": "3.x.x",
     "should": "11.x.x",
     "supertest": "^2.0.1"

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var connect = require("connect")
+  , express = require("express")
   , request = require("supertest")
   , expiry = require('../')
   , path = require('path')
@@ -132,5 +133,23 @@ describe("middleware", function() {
         .expect("Cache-Control", /^private\,/)
       ]);
     });
+  });
+
+  describe("debug route", function() {
+    it("should render with an express or connect app", function() {
+      var expressApp = express()
+        , connectApp = connect()
+        , optionsWithDebug = Object.assign({debug: true}, options)
+        , cacheSnippet = '"/styles.css": "/be625c2b6d6f129c2f2c21a899be0dfb-styles.css"';
+
+      [expressApp, connectApp].forEach(function(app) {
+        app.use(expiry(app, optionsWithDebug));
+      });
+
+      return Promise.all([
+        request(expressApp).get('/expiry').expect(new RegExp(cacheSnippet)),
+        request(expressApp).get('/expiry').expect(new RegExp(cacheSnippet))
+      ]);
+    })
   });
 });


### PR DESCRIPTION
app.get isn’t defined for connect, so we switch it for app.use.

That said, having this debug route seems like it could be a security issue (if the user accidentally deploys with NODE_ENV = development) and like it doesn't add much value, since it's not hard to manually console log expiry.assetCache and expiry.urlCache. How would you feel about removing this route all together for 1.0?